### PR TITLE
[feature] Option to enable internals metrics

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,8 @@
-# Versions 0.4.x
+# Versions
+
+## Version 0.6.0
+
+- Add variable to enable metrics for internal resources (`traefik_metrics_add_internals`)
 
 ## Version 0.5.0
 

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,6 +1,6 @@
 namespace: "epfl_si"
 name: "traefik"
-version: "0.5.0"
+version: "0.6.0"
 readme: "README.md"
 description: "Manage Træfik in basic configurations (HTTP and HTTP/S multiplexing on standard ports)"
 authors:

--- a/roles/traefik/defaults/main.yml
+++ b/roles/traefik/defaults/main.yml
@@ -36,6 +36,8 @@ traefik_use_docker_labels: true  # Ignored if traefik_container_platform is not 
 traefik_produce_access_logs: true
 traefik_debug: false
 
+traefik_metrics_add_internals: false
+
 traefik_log_max_size: 50m
 traefik_log_rotate_keep_number: 3
 

--- a/roles/traefik/templates/traefik.yml
+++ b/roles/traefik/templates/traefik.yml
@@ -28,6 +28,9 @@ api:
 
 metrics:
   prometheus: {}
+{% if traefik_metrics_add_internals %}
+  addInternals: true
+{% endif %}
 
 # So-called “dynamic” configuration providers, which feed in
 # the rest of the configuration


### PR DESCRIPTION
Add an option to enable internal metrics (see https://doc.traefik.io/traefik/observability/metrics/overview/#addinternals)